### PR TITLE
Prevent NativeVote menu from nuking handler

### DIFF
--- a/addons/sourcemod/scripting/nativevotes.sp
+++ b/addons/sourcemod/scripting/nativevotes.sp
@@ -821,7 +821,7 @@ Action DoAction(NativeVote vote, MenuAction action, int param1, int param2, Acti
 {
 	Action res = def_res;
 
-	Handle handler = Data_GetHandler(vote);
+	Handle handler = CloneHandle(Data_GetHandler(vote));
 #if defined LOG
 	LogMessage("Calling Menu forward for vote: %d, handler: %d, action: %d, param1: %d, param2: %d", vote, handler, action, param1, param2);
 #endif
@@ -831,6 +831,7 @@ Action DoAction(NativeVote vote, MenuAction action, int param1, int param2, Acti
 	Call_PushCell(param1);
 	Call_PushCell(param2);
 	Call_Finish(res);
+	delete handler;
 	return res;
 }
 


### PR DESCRIPTION
Increments the refcount of the private forward.  This prevents a crash on Debian 10 and doesn't seem like well-defined behavior.